### PR TITLE
Installs of python, poetry, pipx

### DIFF
--- a/.github/workflows/arduino-compile-sketches.yml
+++ b/.github/workflows/arduino-compile-sketches.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Install Poetry (when running locally for nektos/act compatibility)
         if: ${{ env.ACT }}
         uses: snok/install-poetry@v1
-      - name: Install pipx (when running locally for nektos/act compatibility)
-        if: ${{ env.ACT }}
-        run: pip install pipx
+#      - name: Install pipx (when running locally for nektos/act compatibility)
+#        if: ${{ env.ACT }}
+#        run: pip install pipx
       - name: Copy file if necessary
         if: ${{ inputs.copyfile }}
         run: |

--- a/.github/workflows/arduino-compile-sketches.yml
+++ b/.github/workflows/arduino-compile-sketches.yml
@@ -37,14 +37,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Clone compile-sketches to get python version (using nektos/act locally)
-        if: ${{ env.ACT }}
-        run: cd /tmp; if [ ! -d compile-sketches ]; then git clone 'https://github.com/arduino/compile-sketches'; fi
-      - name: setup-python (when running locally for nektos/act compatibility)
-        if: ${{ env.ACT }}
-        uses: actions/setup-python@v4
-        with:
-          python-version-file: /tmp/compile-sketches/.python-version
+#      - name: Clone compile-sketches to get python version (using nektos/act locally)
+#        if: ${{ env.ACT }}
+#        run: cd /tmp; if [ ! -d compile-sketches ]; then git clone 'https://github.com/arduino/compile-sketches'; fi
+#      - name: setup-python (when running locally for nektos/act compatibility)
+#        if: ${{ env.ACT }}
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version-file: /tmp/compile-sketches/.python-version
       - name: Install Poetry (when running locally for nektos/act compatibility)
         if: ${{ env.ACT }}
         uses: snok/install-poetry@v1

--- a/.github/workflows/arduino-compile-sketches.yml
+++ b/.github/workflows/arduino-compile-sketches.yml
@@ -37,21 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-#      - name: Clone compile-sketches to get python version (using nektos/act locally)
-#        if: ${{ env.ACT }}
-#        run: cd /tmp; if [ ! -d compile-sketches ]; then git clone 'https://github.com/arduino/compile-sketches'; fi
-#      - name: setup-python (when running locally for nektos/act compatibility)
-#        if: ${{ env.ACT }}
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version-file: /tmp/compile-sketches/.python-version
-#      - name: Install Poetry (when running locally for nektos/act compatibility)
-#        if: ${{ env.ACT }}
-#        uses: snok/install-poetry@v1
-#      - name: Install pipx (when running locally for nektos/act compatibility)
-#        if: ${{ env.ACT }}
-#        run: pip install pipx
-      - name: Update PATH
+      - name: Update PATH if using nektos/act locally
+        if: ${{ env.ACT }}
         run: |
           echo "/root/.local/bin" >> $GITHUB_PATH
       - name: Copy file if necessary

--- a/.github/workflows/arduino-compile-sketches.yml
+++ b/.github/workflows/arduino-compile-sketches.yml
@@ -1,8 +1,4 @@
 # Adapted from: https://github.com/marketplace/actions/compile-arduino-sketches
-# 
-# To customize:
-#  - Select which platforms to build and edit the matrix section below
-#  - Add library dependencies as needed for this repo in the libraries section below
 #
 name: Arduino Compile Sketches
 

--- a/.github/workflows/arduino-compile-sketches.yml
+++ b/.github/workflows/arduino-compile-sketches.yml
@@ -45,9 +45,9 @@ jobs:
 #        uses: actions/setup-python@v4
 #        with:
 #          python-version-file: /tmp/compile-sketches/.python-version
-      - name: Install Poetry (when running locally for nektos/act compatibility)
-        if: ${{ env.ACT }}
-        uses: snok/install-poetry@v1
+#      - name: Install Poetry (when running locally for nektos/act compatibility)
+#        if: ${{ env.ACT }}
+#        uses: snok/install-poetry@v1
 #      - name: Install pipx (when running locally for nektos/act compatibility)
 #        if: ${{ env.ACT }}
 #        run: pip install pipx

--- a/.github/workflows/arduino-compile-sketches.yml
+++ b/.github/workflows/arduino-compile-sketches.yml
@@ -51,6 +51,9 @@ jobs:
 #      - name: Install pipx (when running locally for nektos/act compatibility)
 #        if: ${{ env.ACT }}
 #        run: pip install pipx
+      - name: Update PATH
+        run: |
+          echo "/root/.local/bin" >> $GITHUB_PATH
       - name: Copy file if necessary
         if: ${{ inputs.copyfile }}
         run: |


### PR DESCRIPTION
Latest version (published 18-Sep-2023) of ghcr.io/catthehacker/ubuntu:act-latest adds pip and pips to image, so no longer need the manual installs of python, pipe, poetry when running act.